### PR TITLE
fix: `consistent-object-newline`  with CRLF

### DIFF
--- a/src/rules/__snapshots__/consistent-object-newline.test.ts.snap
+++ b/src/rules/__snapshots__/consistent-object-newline.test.ts.snap
@@ -25,6 +25,10 @@ exports[`consistent-object-newline > invalid > const a = {foo: "bar",
 bar: 2
 } 1`] = `"const a = {foo: \\"bar\\", bar: 2}"`;
 
+exports[`consistent-object-newline > invalid > const a = {foo: "bar", \\u000d
+bar: 2\\u000d
+} 1`] = `"const a = {foo: \\"bar\\", bar: 2}"`;
+
 exports[`consistent-object-newline > invalid > import {
 foo, bar } from "foo" 1`] = `
 "import {

--- a/src/rules/consistent-object-newline.test.ts
+++ b/src/rules/consistent-object-newline.test.ts
@@ -20,6 +20,7 @@ const invalid = [
   'const a = [1, \n2, 3\n]',
   'import {\nfoo, bar } from "foo"',
   'import { foo, \nbar } from "foo"',
+  'const a = {foo: "bar", \r\nbar: 2\r\n}',
 ] as const
 
 const ruleTester: RuleTester = new RuleTester({

--- a/src/rules/consistent-object-newline.ts
+++ b/src/rules/consistent-object-newline.ts
@@ -26,7 +26,7 @@ export default createEslintRule<Options, MessageIds>({
     function removeLines(fixer: RuleFixer, start: number, end: number) {
       const range = [start, end] as const
       const code = context.getSourceCode().text.slice(...range)
-      return fixer.replaceTextRange(range, code.replace(/\n/g, ''))
+      return fixer.replaceTextRange(range, code.replace(/(\r\n|\n)/g, ''))
     }
 
     function check(node: TSESTree.Node, items: TSESTree.Node[]) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`consistent-object-newline` will only remove `\n` and leave a lonely `\r` when it encounters CRLF, which may break other rules.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This caused the [failed test](https://github.com/antfu/eslint-config/actions/runs/6272812984/job/17035079729#step:8:136) of `@antfu/eslint-config` on windows:

```
const people: Person[] = [\\r\\n  { name: 'Alice', age: 30 },\\r\\n  { name: 'Bob', age: 25 },\\r\\n  { name: 'Charlie', \r  age: 35 },\\r\\n]\\r\\n\\r\\n
```
