### PR TITLE
fix: update createEslintRule to emit proper urls

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
 
+const hasDocs = ['consistent-list-newline']
+
 export const createEslintRule = ESLintUtils.RuleCreator(
-  ruleName => ruleName,
+  ruleName => hasDocs.includes(ruleName)
+    ? `https://github.com/antfu/eslint-plugin-antfu/blob/main/src/rules/${ruleName}.md`
+    : `https://github.com/antfu/eslint-plugin-antfu/blob/main/src/rules/${ruleName}.test.ts`,
 )


### PR DESCRIPTION
### Description

`ESLintUtils.RuleCreator` is designed to receive a function with your ruleName as an argument and your docs url path as the returned string. This updates your plugin to have your rules point to either the docs for the 1 rule with docs or the tests for the others as the valid/invalid lists are also good docs.

### Additional context

You can preview the change at https://eslint-repl.vercel.app/364130e270ae60ae?lint=EQEwpgtg9g9ALlAtAGwJYDs4DoBWBnYIA&config=EQZwTgxg9ArgLgSwDYgHRxMIA and when you hover over the rule you'll notice the proper url as seen here:

![image](https://github.com/antfu/eslint-plugin-antfu/assets/7559478/2a67dc8c-16b1-4447-9425-1018f994b669)


