### PR TITLE
feat(consistent-list-newline): support jsx attributes

### DIFF
--- a/src/rules/__snapshots__/consistent-list-newline.test.ts.snap
+++ b/src/rules/__snapshots__/consistent-list-newline.test.ts.snap
@@ -177,6 +177,48 @@ Y
 exports[`consistent-list-newline > invalid > foo<X,
 Y>(1, 2) 1`] = `"foo<X,Y>(1, 2)"`;
 
+exports[`consistent-list-newline > invalid > function Foo() {
+  return (
+    <div 
+      className="text-white" onClick="bar"
+      style={{ color: 'red' }}
+    >
+      hi
+    </div>
+  );
+} 1`] = `
+"function Foo() {
+  return (
+    <div 
+      className="text-white" 
+onClick="bar"
+      style={{ color: 'red' }}
+    >
+      hi
+    </div>
+  );
+}"
+`;
+
+exports[`consistent-list-newline > invalid > function Foo() {
+  return (
+    <div className="text-white"
+      onClick="bar"
+      style={{ color: 'red' }}
+    >
+      hi
+    </div>
+  );
+} 1`] = `
+"function Foo() {
+  return (
+    <div className="text-white"      onClick="bar"      style={{ color: 'red' }}    >
+      hi
+    </div>
+  );
+}"
+`;
+
 exports[`consistent-list-newline > invalid > function foo(
 a, b) {} 1`] = `
 "function foo(

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -172,6 +172,40 @@ export default antfu({
 }
   // hello
 )`,
+{
+  code: `function Foo() {
+  return (
+    <div className="text-white"
+      onClick="bar"
+      style={{ color: 'red' }}
+    >
+      hi
+    </div>
+  );
+}`,
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+},
+{
+  code: `function Foo() {
+  return (
+    <div 
+      className="text-white" onClick="bar"
+      style={{ color: 'red' }}
+    >
+      hi
+    </div>
+  );
+}`,
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+},
 ]
 
 const ruleTester: RuleTester = new RuleTester({

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -101,7 +101,25 @@ const a = [
 ];
   `,
   `const a = [(1), (2)];`,
-
+  {
+    code: `function Foo() {
+    return (
+      <div 
+        className="text-white" onClick="bar"
+        style={{
+          color: 'red' 
+        }}
+      >
+        hi
+      </div>
+    );
+  }`,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
 ]
 
 // Check snapshot for fixed code

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -21,6 +21,7 @@ export type Options = [{
   TSTypeParameterInstantiation?: boolean
   ObjectPattern?: boolean
   ArrayPattern?: boolean
+  JSXOpeningElement?: boolean
 }]
 
 export default createEslintRule<Options, MessageIds>({
@@ -51,6 +52,7 @@ export default createEslintRule<Options, MessageIds>({
         TSTypeParameterInstantiation: { type: 'boolean' },
         ObjectPattern: { type: 'boolean' },
         ArrayPattern: { type: 'boolean' },
+        JSXOpeningElement: { type: 'boolean' },
       } satisfies Record<keyof Options[0], { type: 'boolean' }>,
       additionalProperties: false,
     }],
@@ -239,6 +241,9 @@ export default createEslintRule<Options, MessageIds>({
       },
       ArrayPattern(node) {
         check(node, node.elements)
+      },
+      JSXOpeningElement(node) {
+        check(node, node.attributes)
       },
     } satisfies RuleListener
 

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -243,7 +243,7 @@ export default createEslintRule<Options, MessageIds>({
         check(node, node.elements)
       },
       JSXOpeningElement(node) {
-        if (!node.attributes.every(attr => attr.loc.start.line === attr.loc.end.line))
+        if (node.attributes.some(attr => attr.loc.start.line !== attr.loc.end.line))
           return
 
         check(node, node.attributes)

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -243,6 +243,9 @@ export default createEslintRule<Options, MessageIds>({
         check(node, node.elements)
       },
       JSXOpeningElement(node) {
+        if (!node.attributes.every(attr => attr.loc.start.line === attr.loc.end.line))
+          return
+
         check(node, node.attributes)
       },
     } satisfies RuleListener


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

It seems that this rule is not easy to handle when an attribute has multiple rows, so I skip it.

```jsx
function Foo() {
  return (
    <div 
      className="text-white" onClick="bar"
      style={{
        color: 'red' 
      }}
    >
      hi
    </div>
  );
}
```
