### PR TITLE
fix: handle typescript delimiter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
     "source.organizeImports": "never"
   },
 
+  "eslint.runtime": "node",
+
   // Silent the stylistic rules in you IDE, but still auto fix them
   "eslint.rules.customizations": [
     { "rule": "@stylistic/*", "severity": "warn" },

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -142,10 +142,17 @@ const invalid: InvalidTestCase[] = [
   'const foo = (\na, b): {a:b} => {}',
   'interface Foo {\na: 1,b: 2\n}',
   {
-    description: 'Add delimiter to avoid syntax error',
+    description: 'Add delimiter to avoid syntax error, (interface)',
     code: 'interface Foo {a: 1\nb: 2\n}',
     output: o => expect(o)
       .toMatchInlineSnapshot(`"interface Foo {a: 1,b: 2,}"`),
+  },
+  {
+    description: 'Add delimiter to avoid syntax error, (type)',
+    code: 'type Foo = {a: 1\nb: 2\n}',
+    output: o => expect(o)
+      .toMatchInlineSnapshot(`"type Foo = {a: 1,b: 2,}"`),
+    only: true,
   },
   {
     description: 'Delimiter already exists',

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -141,6 +141,20 @@ const invalid: InvalidTestCase[] = [
   'const foo = (\na, b): {\na:b} => {}',
   'const foo = (\na, b): {a:b} => {}',
   'interface Foo {\na: 1,b: 2\n}',
+  {
+    description: 'Add delimiter to avoid syntax error',
+    code: 'interface Foo {a: 1\nb: 2\n}',
+    output: o => expect(o)
+      .toMatchInlineSnapshot(`"interface Foo {a: 1,b: 2,}"`),
+    only: true,
+  },
+  {
+    description: 'Delimiter already exists',
+    code: 'interface Foo {a: 1;\nb: 2,\nc: 3}',
+    output: o => expect(o)
+      .toMatchInlineSnapshot(`"interface Foo {a: 1;b: 2,c: 3}"`),
+    only: true,
+  },
   'type Foo = {\na: 1,b: 2\n}',
   'type Foo = [1,2,\n3]',
   'new Foo(1,2,\n3)',

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -152,7 +152,6 @@ const invalid: InvalidTestCase[] = [
     code: 'type Foo = {a: 1\nb: 2\n}',
     output: o => expect(o)
       .toMatchInlineSnapshot(`"type Foo = {a: 1,b: 2,}"`),
-    only: true,
   },
   {
     description: 'Delimiter already exists',

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -146,14 +146,12 @@ const invalid: InvalidTestCase[] = [
     code: 'interface Foo {a: 1\nb: 2\n}',
     output: o => expect(o)
       .toMatchInlineSnapshot(`"interface Foo {a: 1,b: 2,}"`),
-    only: true,
   },
   {
     description: 'Delimiter already exists',
     code: 'interface Foo {a: 1;\nb: 2,\nc: 3}',
     output: o => expect(o)
       .toMatchInlineSnapshot(`"interface Foo {a: 1;b: 2,c: 3}"`),
-    only: true,
   },
   'type Foo = {\na: 1,b: 2\n}',
   'type Foo = [1,2,\n3]',

--- a/src/rules/consistent-list-newline.test.ts
+++ b/src/rules/consistent-list-newline.test.ts
@@ -148,18 +148,18 @@ const invalid: InvalidTestCase[] = [
       .toMatchInlineSnapshot(`"interface Foo {a: 1,b: 2,}"`),
   },
   {
-    description: 'Add delimiter to avoid syntax error, (type)',
-    code: 'type Foo = {a: 1\nb: 2\n}',
-    output: o => expect(o)
-      .toMatchInlineSnapshot(`"type Foo = {a: 1,b: 2,}"`),
-  },
-  {
     description: 'Delimiter already exists',
     code: 'interface Foo {a: 1;\nb: 2,\nc: 3}',
     output: o => expect(o)
       .toMatchInlineSnapshot(`"interface Foo {a: 1;b: 2,c: 3}"`),
   },
   'type Foo = {\na: 1,b: 2\n}',
+  {
+    description: 'Add delimiter to avoid syntax error, (type)',
+    code: 'type Foo = {a: 1\nb: 2\n}',
+    output: o => expect(o)
+      .toMatchInlineSnapshot(`"type Foo = {a: 1,b: 2,}"`),
+  },
   'type Foo = [1,2,\n3]',
   'new Foo(1,2,\n3)',
   'new Foo(\n1,2,\n3)',

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -70,13 +70,10 @@ export default createEslintRule<Options, MessageIds>({
     }
 
     function getDelimiter(root: TSESTree.Node, current: TSESTree.Node) {
-      let delimiter: string | undefined
-      if (root.type === 'TSInterfaceDeclaration' || root.type === 'TSTypeLiteral') {
-        const currentContent = context.sourceCode.text.slice(current.range[0], current.range[1])
-        if (!currentContent.match(/,|;$/))
-          delimiter = ','
-      }
-      return delimiter
+      if (root.type !== 'TSInterfaceDeclaration' && root.type !== 'TSTypeLiteral')
+        return
+      const currentContent = context.sourceCode.text.slice(current.range[0], current.range[1])
+      return currentContent.match(/,|;$/) ? undefined : ','
     }
 
     function check(

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -71,7 +71,7 @@ export default createEslintRule<Options, MessageIds>({
 
     function getDelimiter(root: TSESTree.Node, current: TSESTree.Node) {
       let delimiter: string | undefined
-      if (root.type === 'TSInterfaceDeclaration') {
+      if (root.type === 'TSInterfaceDeclaration' || root.type === 'TSTypeLiteral') {
         const currentContent = context.sourceCode.text.slice(current.range[0], current.range[1])
         if (!currentContent.match(/,|;$/))
           delimiter = ','

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -63,10 +63,20 @@ export default createEslintRule<Options, MessageIds>({
   },
   defaultOptions: [{}],
   create: (context, [options = {}] = [{}]) => {
-    function removeLines(fixer: RuleFixer, start: number, end: number) {
+    function removeLines(fixer: RuleFixer, start: number, end: number, delimiter?: string) {
       const range = [start, end] as const
       const code = context.sourceCode.text.slice(...range)
-      return fixer.replaceTextRange(range, code.replace(/(\r\n|\n)/g, ''))
+      return fixer.replaceTextRange(range, code.replace(/(\r\n|\n)/g, delimiter ?? ''))
+    }
+
+    function getDelimiter(root: TSESTree.Node, current: TSESTree.Node) {
+      let delimiter: string | undefined
+      if (root.type === 'TSInterfaceDeclaration') {
+        const currentContent = context.sourceCode.text.slice(current.range[0], current.range[1])
+        if (!currentContent.match(/,|;$/))
+          delimiter = ','
+      }
+      return delimiter
     }
 
     function check(
@@ -129,7 +139,7 @@ export default createEslintRule<Options, MessageIds>({
                 name: node.type,
               },
               *fix(fixer) {
-                yield removeLines(fixer, lastItem!.range[1], item.range[0])
+                yield removeLines(fixer, lastItem!.range[1], item.range[0], getDelimiter(node, lastItem))
               },
             })
           }
@@ -175,7 +185,7 @@ export default createEslintRule<Options, MessageIds>({
               name: node.type,
             },
             *fix(fixer) {
-              yield removeLines(fixer, lastItem.range[1], endRange)
+              yield removeLines(fixer, lastItem.range[1], endRange, getDelimiter(node, lastItem))
             },
           })
         }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Before

![ScreenShot 2024-05-18 22 58 39](https://github.com/antfu/eslint-plugin-antfu/assets/38493346/d654cb72-68b8-4e55-901f-9fa477de979d)

After

![ScreenShot 2024-05-18 22 57 06](https://github.com/antfu/eslint-plugin-antfu/assets/38493346/0fa555f1-7028-4f03-a256-a4f9966b9e4b)

### Linked Issues


### Additional context

To test in the editor, I added a vs code setting according to https://github.com/antfu/eslint-ts-patch#integrations

<!-- e.g. is there anything you'd like reviewers to focus on? -->
