### PR TITLE
docs: add docs for all rules and improve onboarding experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,55 @@
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 
-Anthony extended ESLint rules. For [antfu/eslint-config](https://github.com/antfu/eslint-config).
+Anthony's opinionated ESLint rules, used as the foundation of [`@antfu/eslint-config`](https://github.com/antfu/eslint-config).
 
-[Rules List](./src/rules)
+## Install
+
+```bash
+pnpm add -D eslint-plugin-antfu
+```
+
+> Most users should consume these rules via [`@antfu/eslint-config`](https://github.com/antfu/eslint-config), which wires them up with sensible defaults alongside the rest of Anthony's ESLint setup. Install this plugin directly only when you want to pick and choose individual rules.
+
+## Usage
+
+Register the plugin in your flat config and enable the rules you want:
+
+```js
+// eslint.config.js
+import antfu from 'eslint-plugin-antfu'
+
+export default [
+  {
+    plugins: {
+      antfu,
+    },
+    rules: {
+      'antfu/consistent-list-newline': 'error',
+      'antfu/if-newline': 'error',
+      'antfu/top-level-function': 'error',
+    },
+  },
+]
+```
+
+## Rules
+
+<!-- 🔧 = fixable · ⚙️ = configurable -->
+
+| Rule                                                                                | Description                                                                              |     |     |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | :-: | :-: |
+| [`consistent-chaining`](./src/rules/consistent-chaining.md)                         | Enforce consistent line breaks for chaining member access                                | 🔧  | ⚙️  |
+| [`consistent-list-newline`](./src/rules/consistent-list-newline.md)                 | Enforce consistent line breaks inside braces and parentheses                             | 🔧  | ⚙️  |
+| [`curly`](./src/rules/curly.md)                                                     | Opinionated curly bracket enforcement that allows both styles on one-liners              | 🔧  |     |
+| [`if-newline`](./src/rules/if-newline.md)                                           | Enforce a newline between `if` and its consequent                                        | 🔧  |     |
+| [`import-dedupe`](./src/rules/import-dedupe.md)                                     | Auto-fix duplicate named imports from the same source                                    | 🔧  |     |
+| [`indent-unindent`](./src/rules/indent-unindent.md)                                 | Enforce consistent indentation inside `unindent` tagged template strings                 | 🔧  | ⚙️  |
+| [`no-import-dist`](./src/rules/no-import-dist.md)                                   | Prevent importing from a local `dist` folder                                             |     |     |
+| [`no-import-node-modules-by-path`](./src/rules/no-import-node-modules-by-path.md)   | Prevent importing from `node_modules` by relative or absolute path                       |     |     |
+| [`no-top-level-await`](./src/rules/no-top-level-await.md)                           | Prevent top-level `await`                                                                |     |     |
+| [`no-ts-export-equal`](./src/rules/no-ts-export-equal.md)                           | Prevent TypeScript's `export =` syntax in `.ts`/`.tsx`/`.mts`/`.cts` files               |     |     |
+| [`top-level-function`](./src/rules/top-level-function.md)                           | Enforce top-level functions to be declared with the `function` keyword                   | 🔧  |     |
 
 ## Sponsors
 

--- a/src/rules/consistent-chaining.md
+++ b/src/rules/consistent-chaining.md
@@ -25,3 +25,35 @@ const foo2 = []
 ```
 
 It will check the newline style of the **first** property access and apply the same style to the rest of the chaining access.
+
+## Options
+
+```ts
+export default {
+  rules: {
+    'antfu/consistent-chaining': ['error', {
+      allowLeadingPropertyAccess: true,
+    }],
+  },
+}
+```
+
+### `allowLeadingPropertyAccess`
+
+- Type: `boolean`
+- Default: `true`
+
+When enabled, leading inline property accesses on identifiers, literals, `this`, or other member accesses are ignored when deciding the chaining style. This keeps short prefixes like `obj.a.b()` from forcing the rest of the chain onto one line.
+
+<!-- eslint-skip -->
+```js
+// 👍 ok with `allowLeadingPropertyAccess: true` (default)
+foo.bar
+  .map(x => x + 1)
+  .filter(Boolean)
+
+// 👎 reported with `allowLeadingPropertyAccess: false`
+foo.bar
+  .map(x => x + 1)
+  .filter(Boolean)
+```

--- a/src/rules/consistent-chaining.ts
+++ b/src/rules/consistent-chaining.ts
@@ -14,7 +14,7 @@ export default createEslintRule<Options, MessageIds>({
   meta: {
     type: 'layout',
     docs: {
-      description: 'Having line breaks styles to object, array and named imports',
+      description: 'Enforce consistent line breaks for chaining member access',
     },
     fixable: 'whitespace',
     schema: [

--- a/src/rules/consistent-list-newline.md
+++ b/src/rules/consistent-list-newline.md
@@ -28,9 +28,47 @@ const foo = { bar: 'baz', qux: 'quux', fez: 'fum' }
 
 It will check the newline style of the **first** property or item and apply to the rest of the properties or items. So you can also use this rule to quite wrap / unwrap your code.
 
+## Options
+
+Every node type the rule handles can be individually disabled. Set a key to `false` to opt out of checking that node type. By default, all are enabled.
+
+```ts
+export default {
+  rules: {
+    'antfu/consistent-list-newline': ['error', {
+      ObjectExpression: false, // don't check object literals
+    }],
+  },
+}
+```
+
+| Option                         | Example                                |
+| ------------------------------ | -------------------------------------- |
+| `ArrayExpression`              | `[a, b, c]`                            |
+| `ArrayPattern`                 | `const [a, b] = arr`                   |
+| `ArrowFunctionExpression`      | `(a, b) => …` (only when >1 param)     |
+| `CallExpression`               | `fn(a, b, c)`                          |
+| `ExportNamedDeclaration`       | `export { a, b } from '…'`             |
+| `FunctionDeclaration`          | `function f(a, b) {}`                  |
+| `FunctionExpression`           | `function (a, b) {}`                   |
+| `IfStatement`                  | `if (a)` / `if (a, b)`                 |
+| `ImportDeclaration`            | `import { a, b } from '…'`             |
+| `JSONArrayExpression`          | JSON array literals                    |
+| `JSONObjectExpression`         | JSON object literals                   |
+| `JSXOpeningElement`            | `<Foo a b />`                          |
+| `NewExpression`                | `new Foo(a, b)`                        |
+| `ObjectExpression`             | `{ a, b }`                             |
+| `ObjectPattern`                | `const { a, b } = obj`                 |
+| `TSFunctionType`               | `(a: string) => void`                  |
+| `TSInterfaceDeclaration`       | `interface Foo { a: 1; b: 2 }`         |
+| `TSTupleType`                  | `[A, B]`                               |
+| `TSTypeLiteral`                | `type Foo = { a: 1; b: 2 }`            |
+| `TSTypeParameterDeclaration`   | `function f<A, B>() {}`                |
+| `TSTypeParameterInstantiation` | `f<A, B>()`                            |
+
 ## Rule Conflicts
 
-This rule might conflicts with the [object-curly-newline](https://eslint.org/docs/rules/object-curly-newline). You can turn if off.
+This rule might conflict with [object-curly-newline](https://eslint.org/docs/rules/object-curly-newline). You can turn it off:
 
 ```ts
 export default {

--- a/src/rules/consistent-list-newline.ts
+++ b/src/rules/consistent-list-newline.ts
@@ -37,7 +37,7 @@ export default createEslintRule<Options, MessageIds>({
   meta: {
     type: 'layout',
     docs: {
-      description: 'Having line breaks styles to object, array and named imports',
+      description: 'Enforce consistent line breaks inside braces and parentheses',
     },
     fixable: 'whitespace',
     schema: [{

--- a/src/rules/indent-unindent.md
+++ b/src/rules/indent-unindent.md
@@ -44,6 +44,33 @@ const cases = [
 
 By default it affects the template tag named `unindent`, `unIndent` or `$`. This rule works specifically for the `unindent` utility function from [`@antfu/utils`](https://github.com/antfu), where the leading and trailing empty lines are removed, and the common indentation is removed from each line. This rule fixes the content inside the template string but shall not affect the runtime result.
 
+## Options
+
+```ts
+export default {
+  rules: {
+    'antfu/indent-unindent': ['error', {
+      indent: 2,
+      tags: ['$', 'unindent', 'unIndent'],
+    }],
+  },
+}
+```
+
+### `indent`
+
+- Type: `number`
+- Default: `2`
+
+Number of spaces to indent the template content relative to the surrounding code.
+
+### `tags`
+
+- Type: `string[]`
+- Default: `['$', 'unindent', 'unIndent']`
+
+The list of template tag identifiers the rule applies to. Matching is done by identifier name only — the rule does not check where the tag is imported from, so any local alias with one of these names will be picked up.
+
 ## Known issues
 
 This rule will report errors when files use `CRLF`.

--- a/src/rules/no-import-dist.md
+++ b/src/rules/no-import-dist.md
@@ -1,0 +1,26 @@
+# no-import-dist
+
+Prevent importing from a local `dist` folder. Distributed bundles should not be imported directly — import from the package source or its public entry instead.
+
+## Rule Details
+
+<!-- eslint-skip -->
+```js
+// 👎 bad
+import a from '../dist/a'
+import '../dist/b'
+import b from 'dist'
+import c from './dist'
+```
+
+<!-- eslint-skip -->
+```js
+// 👍 good
+import xxx from 'a'
+import 'b'
+
+// Importing assets from a published package's `dist` is fine
+import 'floating-vue/dist/foo.css'
+```
+
+The rule only flags imports that look like a local `dist` folder — either the bare specifier `dist`, a relative path starting with `./dist` or `../dist`, or any relative path containing `/dist/`. Imports of files inside a published package's `dist` (e.g. `floating-vue/dist/foo.css`) are intentionally allowed.

--- a/src/rules/no-import-node-modules-by-path.md
+++ b/src/rules/no-import-node-modules-by-path.md
@@ -1,0 +1,25 @@
+# no-import-node-modules-by-path
+
+Prevent importing from `node_modules` by relative or absolute path. Reach for modules by their package name and let the resolver do its job.
+
+## Rule Details
+
+<!-- eslint-skip -->
+```js
+// 👎 bad
+import a from '../node_modules/a'
+import '../node_modules/b'
+const c = require('../node_modules/c')
+require('../node_modules/d')
+```
+
+<!-- eslint-skip -->
+```js
+// 👍 good
+import xxx from 'a'
+import 'b'
+const c = require('c')
+require('d')
+```
+
+Both `import` declarations and `require()` calls are checked. A specifier is flagged when its string value contains `/node_modules/`.

--- a/src/rules/no-top-level-await.md
+++ b/src/rules/no-top-level-await.md
@@ -1,0 +1,33 @@
+# no-top-level-await
+
+Prevent `await` outside an `async` function. Top-level `await` is only valid in ESM modules and bundlers/runtimes that support it — using it can break compatibility with CJS consumers or older targets.
+
+## Rule Details
+
+<!-- eslint-skip -->
+```js
+// 👎 bad
+await foo()
+
+const a = {
+  foo: await bar()
+}
+```
+
+<!-- eslint-skip -->
+```js
+// 👍 good
+async function foo() {
+  await bar()
+}
+
+const a = async () => {
+  await bar()
+}
+```
+
+The rule walks up from each `AwaitExpression` and reports it when no enclosing `FunctionDeclaration`, `FunctionExpression`, or `ArrowFunctionExpression` is found.
+
+## When Not To Use It
+
+If you're authoring an application or ESM-only library that targets environments where top-level `await` is supported (modern browsers, Node.js 14.8+ ESM, Deno, Bun), you can safely disable this rule.

--- a/src/rules/no-ts-export-equal.md
+++ b/src/rules/no-ts-export-equal.md
@@ -1,0 +1,19 @@
+# no-ts-export-equal
+
+Disallow TypeScript's `export =` syntax. Use the ESM `export default` form instead — it interoperates cleanly with modern bundlers and Node.js ESM.
+
+## Rule Details
+
+<!-- eslint-skip -->
+```ts
+// 👎 bad
+export = {}
+```
+
+<!-- eslint-skip -->
+```ts
+// 👍 good
+export default {}
+```
+
+This rule only fires inside TypeScript files (`.ts`, `.tsx`, `.mts`, `.cts`). `export =` in plain JavaScript files is left untouched.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,17 +2,6 @@ import type { RuleListener, RuleWithMeta, RuleWithMetaAndName } from '@typescrip
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { Rule } from 'eslint'
 
-// @keep-sorted
-const hasDocs = [
-  'consistent-chaining',
-  'consistent-list-newline',
-  'curly',
-  'if-newline',
-  'import-dedupe',
-  'indent-unindent',
-  'top-level-function',
-]
-
 const blobUrl = 'https://github.com/antfu/eslint-plugin-antfu/blob/main/src/rules/'
 
 export type RuleModule<
@@ -83,9 +72,7 @@ function createRule<
 }
 
 export const createEslintRule = RuleCreator(
-  ruleName => hasDocs.includes(ruleName)
-    ? `${blobUrl}${ruleName}.md`
-    : `${blobUrl}${ruleName}.test.ts`,
+  ruleName => `${blobUrl}${ruleName}.md`,
 ) as any as <TOptions extends readonly unknown[], TMessageIds extends string>({ name, meta, ...rule }: Readonly<RuleWithMetaAndName<TOptions, TMessageIds>>) => RuleModule<TOptions>
 
 const warned = new Set<string>()


### PR DESCRIPTION
## Summary

- Adds Markdown docs for the four previously undocumented rules (`no-import-dist`, `no-import-node-modules-by-path`, `no-top-level-await`, `no-ts-export-equal`) and an `## Options` section for the three rules that expose configuration (`consistent-chaining`, `consistent-list-newline`, `indent-unindent`).
- Drops the `hasDocs` allowlist in `src/utils.ts` — every rule's `meta.docs.url` now points at its `.md` file instead of falling back to the test file.
- Fixes the wrong `meta.docs.description` on `consistent-chaining` (copy-pasted from another rule) and tightens the one on `consistent-list-newline`.
- Rewrites `README.md` with install instructions, a flat-config usage example, a pointer to `@antfu/eslint-config`, and a rules table with 🔧 (fixable) / ⚙️ (configurable) flags linking to each rule's doc.

fix #49

## Test plan

- [x] `pnpm test` — all 193 tests pass
- [x] `pnpm exec eslint src README.md` — clean
- [x] `pnpm build` — succeeds; verified at runtime that `no-import-dist`'s `meta.docs.url` now resolves to `.../no-import-dist.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)