### PR TITLE
chore: normalize npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "type": "git",
     "url": "git+https://github.com/antfu/eslint-plugin-antfu.git"
   },
-  "bugs": "https://github.com/antfu/eslint-plugin-antfu/issues",
+  "bugs": {
+    "url": "https://github.com/antfu/eslint-plugin-antfu/issues"
+  },
   "keywords": [
     "eslint-plugin"
   ],


### PR DESCRIPTION
## Summary

- change the package `bugs` metadata from a string to the standard `{ "url": ... }` object form
- keep the existing issue tracker URL unchanged

## Validation

- `node -e "const p=require('./package.json'); if(p.name!=='eslint-plugin-antfu'||p.homepage!=='https://github.com/antfu/eslint-plugin-antfu#readme'||p.bugs?.url!=='https://github.com/antfu/eslint-plugin-antfu/issues') process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository}, null, 2))"`
- `npm pack --dry-run --json`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `git diff --check`
